### PR TITLE
feat: replace execSync with execFileSync (proper arg escaping)

### DIFF
--- a/source/cli/src/core/dependency-resolver.ts
+++ b/source/cli/src/core/dependency-resolver.ts
@@ -1,5 +1,5 @@
 import type { Graph, Stage } from '../model/types.js';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 
 export interface ResolveOptions {
@@ -43,7 +43,7 @@ export function findChangedNodes(graph: Graph, ref?: string): string[] {
 
   let changedFiles: string[];
   try {
-    const output = execSync(`git diff --name-only ${gitRef} -- ${yggDirName}/`, {
+    const output = execFileSync('git', ['diff', '--name-only', gitRef, '--', `${yggDirName}/`], {
       cwd: projectRoot,
       encoding: 'utf-8',
     }).trim();

--- a/source/cli/src/core/graph-from-git.ts
+++ b/source/cli/src/core/graph-from-git.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { loadGraph } from './graph-loader.js';
 import type { Graph } from '../model/types.js';
 
@@ -17,7 +17,7 @@ export async function loadGraphFromRef(
   let tmpDir: string | null = null;
 
   try {
-    execSync(`git rev-parse ${ref}`, { cwd: projectRoot, stdio: 'pipe' });
+    execFileSync('git', ['rev-parse', ref], { cwd: projectRoot, stdio: 'pipe' });
   } catch {
     return null;
   }
@@ -25,11 +25,11 @@ export async function loadGraphFromRef(
   try {
     tmpDir = await mkdtemp(path.join(tmpdir(), 'ygg-git-'));
     const archivePath = path.join(tmpDir, 'archive.tar');
-    execSync(`git archive ${ref} ${yggPath} -o "${archivePath}"`, {
+    execFileSync('git', ['archive', ref, yggPath, '-o', archivePath], {
       cwd: projectRoot,
       stdio: 'pipe',
     });
-    execSync(`tar -xf "${archivePath}" -C "${tmpDir}"`, { stdio: 'pipe' });
+    execFileSync('tar', ['-xf', archivePath, '-C', tmpDir], { stdio: 'pipe' });
     const graph = await loadGraph(tmpDir);
     return graph;
   } catch {

--- a/source/cli/src/utils/git.ts
+++ b/source/cli/src/utils/git.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 
 /**
@@ -9,7 +9,7 @@ import path from 'node:path';
 export function getLastCommitTimestamp(projectRoot: string, relativePath: string): number | null {
   const normalized = path.normalize(relativePath).replace(/\\/g, '/');
   try {
-    const out = execSync(`git log -1 --format=%ct -- "${normalized}"`, {
+    const out = execFileSync('git', ['log', '-1', '--format=%ct', '--', normalized], {
       cwd: projectRoot,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/source/cli/tests/unit/core/dependency-resolver.test.ts
+++ b/source/cli/tests/unit/core/dependency-resolver.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 import {
   resolveDeps,
@@ -266,7 +266,7 @@ describe('dependency-resolver', () => {
 
   describe('resolveDeps - changed mode', () => {
     it('uses changed mode to filter nodes', async () => {
-      vi.mocked(execSync).mockReturnValue('.yggdrasil/changed/yg-node.yaml\n');
+      vi.mocked(execFileSync).mockReturnValue('.yggdrasil/changed/yg-node.yaml\n');
 
       const graph = createGraph(
         [
@@ -291,7 +291,7 @@ describe('dependency-resolver', () => {
     });
 
     it('skips blackbox nodes', () => {
-      vi.mocked(execSync).mockReturnValue('.yggdrasil/blackbox-node/yg-node.yaml\n');
+      vi.mocked(execFileSync).mockReturnValue('.yggdrasil/blackbox-node/yg-node.yaml\n');
 
       const graph = createGraph(
         [
@@ -312,7 +312,7 @@ describe('dependency-resolver', () => {
     it('skips nodes without mapping', () => {
       // Git reports changes but node has no mapping — findChangedNodes still returns it,
       // resolveDeps filters later
-      vi.mocked(execSync).mockReturnValue('');
+      vi.mocked(execFileSync).mockReturnValue('');
 
       const graph = createGraph(
         [
@@ -326,7 +326,7 @@ describe('dependency-resolver', () => {
     });
 
     it('maps git diff output to correct node paths', () => {
-      vi.mocked(execSync).mockReturnValue(
+      vi.mocked(execFileSync).mockReturnValue(
         '.yggdrasil/auth/login-service/yg-node.yaml\n.yggdrasil/auth/login-service/aspects/api.yaml\n',
       );
 
@@ -344,7 +344,7 @@ describe('dependency-resolver', () => {
     });
 
     it('returns empty when git diff fails', () => {
-      vi.mocked(execSync).mockImplementation(() => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         throw new Error('not a git repo');
       });
 
@@ -355,19 +355,20 @@ describe('dependency-resolver', () => {
     });
 
     it('uses custom ref when provided', () => {
-      vi.mocked(execSync).mockReturnValue('.yggdrasil/my-node/yg-node.yaml\n');
+      vi.mocked(execFileSync).mockReturnValue('.yggdrasil/my-node/yg-node.yaml\n');
 
       const graph = createGraph([createNode('my-node', [], { path: 'src/my.ts' })], rootPath);
 
       findChangedNodes(graph, 'main');
-      expect(vi.mocked(execSync)).toHaveBeenCalledWith(
-        'git diff --name-only main -- .yggdrasil/',
+      expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+        'git',
+        ['diff', '--name-only', 'main', '--', '.yggdrasil/'],
         expect.objectContaining({ cwd: '/tmp/test-ygg', encoding: 'utf-8' }),
       );
     });
 
     it('expands with one-level dependents only (no cascade)', () => {
-      vi.mocked(execSync).mockReturnValue('.yggdrasil/base/yg-node.yaml\n');
+      vi.mocked(execFileSync).mockReturnValue('.yggdrasil/base/yg-node.yaml\n');
 
       const graph = createGraph(
         [
@@ -385,7 +386,7 @@ describe('dependency-resolver', () => {
     });
 
     it('handles file path without ygg prefix (relative path)', () => {
-      vi.mocked(execSync).mockReturnValue('model/svc/yg-node.yaml\n');
+      vi.mocked(execFileSync).mockReturnValue('model/svc/yg-node.yaml\n');
 
       const graph = createGraph([createNode('svc', [], { path: 'src/svc.ts' })], rootPath);
 
@@ -394,7 +395,7 @@ describe('dependency-resolver', () => {
     });
 
     it('handles path without model segment (skips non-node paths)', () => {
-      vi.mocked(execSync).mockReturnValue('yg-config.yaml\naspects/audit/yg-aspect.yaml\n');
+      vi.mocked(execFileSync).mockReturnValue('yg-config.yaml\naspects/audit/yg-aspect.yaml\n');
 
       const graph = createGraph([createNode('svc', [], { path: 'src/svc.ts' })], rootPath);
 

--- a/source/cli/tests/unit/core/graph-from-git.test.ts
+++ b/source/cli/tests/unit/core/graph-from-git.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { loadGraphFromRef } from '../../../src/core/graph-from-git.js';
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 describe('graph-from-git', () => {
   beforeEach(() => {
-    vi.mocked(execSync).mockReset();
+    vi.mocked(execFileSync).mockReset();
   });
 
   afterEach(() => {
@@ -16,32 +16,33 @@ describe('graph-from-git', () => {
   });
 
   it('returns null when not a git repo', async () => {
-    vi.mocked(execSync).mockImplementation(() => {
+    vi.mocked(execFileSync).mockImplementation(() => {
       throw new Error('not a git repository');
     });
 
     const result = await loadGraphFromRef('/tmp/empty');
 
     expect(result).toBeNull();
-    expect(execSync).toHaveBeenCalledWith(
-      'git rev-parse HEAD',
+    expect(execFileSync).toHaveBeenCalledWith(
+      'git',
+      ['rev-parse', 'HEAD'],
       expect.objectContaining({ cwd: '/tmp/empty' }),
     );
   });
 
   it('returns null when ref does not exist', async () => {
-    vi.mocked(execSync).mockImplementation(() => {
+    vi.mocked(execFileSync).mockImplementation(() => {
       throw new Error('bad revision');
     });
 
     const result = await loadGraphFromRef('/tmp/repo', 'nonexistent-ref');
 
     expect(result).toBeNull();
-    expect(execSync).toHaveBeenCalledWith('git rev-parse nonexistent-ref', expect.any(Object));
+    expect(execFileSync).toHaveBeenCalledWith('git', ['rev-parse', 'nonexistent-ref'], expect.any(Object));
   });
 
   it('returns null when git archive fails', async () => {
-    vi.mocked(execSync)
+    vi.mocked(execFileSync)
       .mockImplementationOnce(() => Buffer.from('abc123'))
       .mockImplementationOnce(() => {
         throw new Error('path not found in archive');
@@ -53,7 +54,7 @@ describe('graph-from-git', () => {
   });
 
   it('returns null when tar extract fails', async () => {
-    vi.mocked(execSync)
+    vi.mocked(execFileSync)
       .mockImplementationOnce(() => Buffer.from('abc123'))
       .mockImplementationOnce(() => Buffer.from(''))
       .mockImplementationOnce(() => {
@@ -69,12 +70,12 @@ describe('graph-from-git', () => {
     const path = await import('node:path');
     const { mkdirSync, writeFileSync } = await import('node:fs');
 
-    vi.mocked(execSync)
+    vi.mocked(execFileSync)
       .mockImplementationOnce(() => Buffer.from('abc123'))
       .mockImplementationOnce(() => Buffer.from(''))
-      .mockImplementationOnce((cmd: string) => {
-        const match = cmd.match(/-C "([^"]+)"/);
-        const extractDir = match?.[1];
+      .mockImplementationOnce((_cmd: string, args?: readonly string[]) => {
+        const cFlagIndex = args?.indexOf('-C');
+        const extractDir = cFlagIndex !== undefined && cFlagIndex >= 0 ? args?.[cFlagIndex + 1] : undefined;
         if (extractDir) {
           const yggRoot = path.join(extractDir, '.yggdrasil');
           mkdirSync(path.join(yggRoot, 'model'), { recursive: true });
@@ -91,12 +92,12 @@ describe('graph-from-git', () => {
     const path = await import('node:path');
     const { mkdirSync, writeFileSync } = await import('node:fs');
 
-    vi.mocked(execSync)
+    vi.mocked(execFileSync)
       .mockImplementationOnce(() => Buffer.from('abc123'))
       .mockImplementationOnce(() => Buffer.from(''))
-      .mockImplementationOnce((cmd: string) => {
-        const match = cmd.match(/-C "([^"]+)"/);
-        const extractDir = match?.[1];
+      .mockImplementationOnce((_cmd: string, args?: readonly string[]) => {
+        const cFlagIndex = args?.indexOf('-C');
+        const extractDir = cFlagIndex !== undefined && cFlagIndex >= 0 ? args?.[cFlagIndex + 1] : undefined;
         if (extractDir) {
           const yggRoot = path.join(extractDir, '.yggdrasil');
           mkdirSync(path.join(yggRoot, 'model', 'svc'), { recursive: true });

--- a/source/cli/tests/unit/utils/git.test.ts
+++ b/source/cli/tests/unit/utils/git.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getLastCommitTimestamp } from '../../../src/utils/git.js';
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -13,34 +13,35 @@ const FIXTURE_ROOT = path.join(__dirname, '../../fixtures/sample-project');
 
 describe('git', () => {
   beforeEach(() => {
-    vi.mocked(execSync).mockReset();
+    vi.mocked(execFileSync).mockReset();
   });
 
   describe('getLastCommitTimestamp', () => {
     it('returns timestamp when git log succeeds with valid output', () => {
-      vi.mocked(execSync).mockReturnValue('1730000000\n' as unknown as Buffer);
+      vi.mocked(execFileSync).mockReturnValue('1730000000\n' as unknown as Buffer);
       const result = getLastCommitTimestamp(FIXTURE_ROOT, '.yggdrasil/yg-config.yaml');
       expect(result).toBe(1730000000);
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining('git log -1 --format=%ct'),
+      expect(execFileSync).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['log', '-1', '--format=%ct']),
         expect.any(Object),
       );
     });
 
     it('returns null when git log returns non-numeric output', () => {
-      vi.mocked(execSync).mockReturnValue('' as unknown as Buffer);
+      vi.mocked(execFileSync).mockReturnValue('' as unknown as Buffer);
       const result = getLastCommitTimestamp(FIXTURE_ROOT, 'nonexistent');
       expect(result).toBeNull();
     });
 
     it('returns null when parseInt produces NaN', () => {
-      vi.mocked(execSync).mockReturnValue('not-a-number' as unknown as Buffer);
+      vi.mocked(execFileSync).mockReturnValue('not-a-number' as unknown as Buffer);
       const result = getLastCommitTimestamp(FIXTURE_ROOT, 'some/path');
       expect(result).toBeNull();
     });
 
-    it('returns null when execSync throws (not a git repo or path has no commits)', () => {
-      vi.mocked(execSync).mockImplementation(() => {
+    it('returns null when execFileSync throws (not a git repo or path has no commits)', () => {
+      vi.mocked(execFileSync).mockImplementation(() => {
         throw new Error('fatal: not a git repository');
       });
       const result = getLastCommitTimestamp('/tmp/not-a-repo', 'any/path');
@@ -48,10 +49,11 @@ describe('git', () => {
     });
 
     it('normalizes Windows-style paths to forward slashes', () => {
-      vi.mocked(execSync).mockReturnValue('1730000000\n' as unknown as Buffer);
+      vi.mocked(execFileSync).mockReturnValue('1730000000\n' as unknown as Buffer);
       getLastCommitTimestamp(FIXTURE_ROOT, 'path\\with\\backslashes');
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringMatching(/path\/with\/backslashes/),
+      expect(execFileSync).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining([expect.stringMatching(/path\/with\/backslashes/)]),
         expect.any(Object),
       );
     });


### PR DESCRIPTION
It's a minor thing, just safety of passing args to sub-command invocations.