### PR TITLE
feat: add CodeBuddy platform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Invariant extraction step (4b) in reverse-engineering protocol.** Instructs
   agents to scan for guards, throws, and conditionals and record them as
   behavioral invariants.
+- **CodeBuddy platform support.** `yg init --platform codebuddy` creates
+  `.codebuddy/rules/yggdrasil/RULE.mdc` with `alwaysApply: true` frontmatter,
+  integrating Yggdrasil's agent rules into CodeBuddy's project-level rule system.
 
 ### Changed
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -17,7 +17,7 @@ yg init [--platform <name>] [--upgrade]
 
 Creates `.yggdrasil/` and installs the platform instruction file.
 
-- `--platform <name>` — Agent platform (default: `generic`). Values: `cursor`, `claude-code`, `copilot`, `cline`, `roocode`, `codex`, `windsurf`, `aider`, `gemini`, `amp`, `generic`
+- `--platform <name>` — Agent platform (default: `generic`). Values: `cursor`, `claude-code`, `copilot`, `cline`, `roocode`, `codex`, `windsurf`, `aider`, `gemini`, `amp`, `codebuddy`, `generic`
 - `--upgrade` — Refresh rules only when `.yggdrasil/` already exists
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ yg init --platform <platform>
 ```
 
 Supported platforms: `cursor`, `claude-code`, `copilot`, `cline`,
-`roocode`, `codex`, `windsurf`, `aider`, `gemini`, `amp`, `generic`
+`roocode`, `codex`, `windsurf`, `aider`, `gemini`, `amp`, `codebuddy`, `generic`
 
 ## 3) Start coding
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -17,6 +17,7 @@ instruction file — so the agent knows how to use the repo's semantic memory.
 | Aider | `.aider.conf.yml` (adds `read:` entry) | ⚠️ Minimal (1 line) |
 | Gemini CLI | `GEMINI.md` (single `@...` line) | ⚠️ Minimal (1 line) |
 | Amp | `AGENTS.md` (single `@...` line) | ⚠️ Minimal (1 line) |
+| CodeBuddy | `.codebuddy/rules/yggdrasil/RULE.mdc` | ❌ No |
 | Generic | `.yggdrasil/agent-rules.md` | ❌ No |
 
 Notes:

--- a/source/cli/src/cli/init.ts
+++ b/source/cli/src/cli/init.ts
@@ -49,7 +49,7 @@ export function registerInitCommand(program: Command): void {
     .description('Initialize Yggdrasil graph in current project')
     .option(
       '--platform <name>',
-      'Agent platform: cursor, claude-code, copilot, cline, roocode, codex, windsurf, aider, gemini, amp, generic',
+      'Agent platform: cursor, claude-code, copilot, cline, roocode, codex, windsurf, aider, gemini, amp, codebuddy, generic',
       'generic',
     )
     .option('--upgrade', 'Refresh rules only (when .yggdrasil/ already exists)')

--- a/source/cli/src/templates/platform.ts
+++ b/source/cli/src/templates/platform.ts
@@ -19,6 +19,7 @@ export type Platform =
   | 'aider'
   | 'gemini'
   | 'amp'
+  | 'codebuddy'
   | 'generic';
 
 export const PLATFORMS: Platform[] = [
@@ -32,6 +33,7 @@ export const PLATFORMS: Platform[] = [
   'aider',
   'gemini',
   'amp',
+  'codebuddy',
   'generic',
 ];
 
@@ -62,6 +64,8 @@ export async function installRulesForPlatform(
       return installForGemini(projectRoot, agentRulesPath);
     case 'amp':
       return installForAmp(projectRoot, agentRulesPath);
+    case 'codebuddy':
+      return installForCodeBuddy(projectRoot);
     case 'generic':
     default:
       return installForGeneric(projectRoot);
@@ -226,6 +230,20 @@ async function installForGemini(projectRoot: string, agentRulesPath: string): Pr
   const content = existing.trimEnd() ? `${existing.trimEnd()}\n${importLine}\n` : `${importLine}\n`;
   await writeFile(filePath, content, 'utf-8');
   return agentRulesPath;
+}
+
+async function installForCodeBuddy(projectRoot: string): Promise<string> {
+  const dir = path.join(projectRoot, '.codebuddy', 'rules', 'yggdrasil');
+  await mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, 'RULE.mdc');
+  const content = `---
+description: Yggdrasil — semantic memory of the repository
+alwaysApply: true
+---
+
+${AGENT_RULES_CONTENT}`;
+  await writeFile(filePath, content, 'utf-8');
+  return filePath;
 }
 
 async function installForAmp(projectRoot: string, agentRulesPath: string): Promise<string> {

--- a/source/cli/tests/unit/templates/platform.test.ts
+++ b/source/cli/tests/unit/templates/platform.test.ts
@@ -26,6 +26,7 @@ describe('installRulesForPlatform', () => {
     expect(PLATFORMS).toContain('aider');
     expect(PLATFORMS).toContain('gemini');
     expect(PLATFORMS).toContain('amp');
+    expect(PLATFORMS).toContain('codebuddy');
     expect(PLATFORMS).toContain('generic');
   });
 
@@ -150,6 +151,19 @@ describe('installRulesForPlatform', () => {
       const content = readFileSync(path.join(root, 'AGENTS.md'), 'utf-8');
       expect(content).toContain('## Project rules');
       expect(content).toContain('@.yggdrasil/agent-rules.md');
+    });
+  });
+
+  it('codebuddy when empty: creates .codebuddy/rules/yggdrasil/RULE.mdc with frontmatter', async () => {
+    await withTempDir(async (root) => {
+      const out = await installRulesForPlatform(root, 'codebuddy');
+      expect(out).toBe(path.join(root, '.codebuddy', 'rules', 'yggdrasil', 'RULE.mdc'));
+      expect(existsSync(out)).toBe(true);
+      const content = readFileSync(out, 'utf-8');
+      expect(content).toContain('---');
+      expect(content).toContain('description: Yggdrasil — semantic memory of the repository');
+      expect(content).toContain('alwaysApply: true');
+      expect(content).toContain(AGENT_RULES_CONTENT);
     });
   });
 


### PR DESCRIPTION
- Add 'codebuddy' to Platform type and PLATFORMS array
- Implement installForCodeBuddy() that creates .codebuddy/rules/yggdrasil/RULE.mdc
- Update CLI --platform option description
- Add comprehensive test for CodeBuddy platform
- Update documentation: platforms.md, cli-reference.md, getting-started.md
- Add entry to CHANGELOG.md under [Unreleased]

This enables users to run 'yg init --platform codebuddy' to integrate Yggdrasil's semantic memory with CodeBuddy's project-level rule system. The rules are placed in the exact location CodeBuddy expects and are marked with 'alwaysApply: true' for automatic loading in every session.