### PR TITLE
fix(ci): satisfy the 5.4.0 portal gate in a fresh CI checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
         working-directory: source/cli
       - run: npm ci
         working-directory: docs
+      # The portal e2e gate inside repo-check.sh drives a REAL Chromium through
+      # Playwright. Chromium is rebuildable, not committed, so CI must install it
+      # before the gate runs — otherwise repo-check.sh's Chromium-present guard
+      # fails closed (a missing browser must never be a silent green). This is the
+      # exact command that guard prints.
+      - run: npx playwright install --with-deps chromium
+        working-directory: source/cli
       - run: scripts/repo-check.sh
       - uses: codecov/codecov-action@v7
         # Upload coverage from a single matrix leg to avoid duplicate reports.

--- a/.yggdrasil/yg-lock.nondeterministic.json
+++ b/.yggdrasil/yg-lock.nondeterministic.json
@@ -400,7 +400,7 @@
       "file:source/cli/tests/integration/ollama-reviewer.external.test.ts": {"hash":"c47d1343aa31beb53a36a643c01fe01fddd33b755537485cd5900e691a70e41c","verdict":"approved"},
       "file:source/cli/tests/integration/portal-attestation-meta.test.ts": {"hash":"eaa004f7deab4d5bf369075afbc375191605592e94ca92fe9d25ff172e97315b","verdict":"approved"},
       "file:source/cli/tests/integration/portal-boundary.test.ts": {"hash":"25080a2e5ce000937a8e67688ec1091c498a9d567d9b596e042bcc0e6e03c382","verdict":"approved"},
-      "file:source/cli/tests/integration/portal-derive-catalogue.test.ts": {"hash":"5781ad29ce555beffa3e42287e0012555ba097de0a2e6f7b4383b1266872d540","verdict":"approved"},
+      "file:source/cli/tests/integration/portal-derive-catalogue.test.ts": {"hash":"391b40e6ebaa1d1e8be54ffda09e047930c02591c1fbbdae377c5cc87f945f23","verdict":"approved"},
       "file:source/cli/tests/integration/portal-derive-nodes.test.ts": {"hash":"6d7883e973138805647ef2c285dfc163245718dfd5a3abeb47889d18613dfadb","verdict":"approved"},
       "file:source/cli/tests/integration/portal-derive-rest.test.ts": {"hash":"3196a0f5141bd81864fa4e85620dfedde6dd7d79280affdc850c3257a094717d","verdict":"approved"},
       "file:source/cli/tests/integration/portal-engine-api-provenance.test.ts": {"hash":"7a8cc9cc9a6d8ba396fe4f858e3a2d320f40152191722734dc69a0bb329256e6","verdict":"approved"},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI now passes the portal quality gate it introduced in 5.4.0 (dev-infra only; no change to the published CLI).** The 5.4.0 portal work added a Playwright + Chromium e2e gate and deterministic-cache-backed portal integration tests to `repo-check.sh`, but the CI workflow was never taught to satisfy them in a fresh checkout: Chromium is rebuildable (not committed) and was never installed, and the gitignored deterministic-verdict cache (`.yg-lock.deterministic.json`) was rebuilt only at the very end of `repo-check.sh` — after the tests that read it — so the portal count-parity assertions saw `unverified` pairs and failed. CI now installs Chromium before the gate, `repo-check.sh` rebuilds the deterministic cache before the test run (so a clean clone passes the same as a warm working tree), and the one heavy whole-repo catalogue test carries the same explicit timeout budget as its sibling heavy work so a slow runner no longer trips vitest's 5s default. No source or graph behavior changed.
+
 ## [5.4.0] - 2026-06-30
 
 ### Added

--- a/scripts/repo-check.sh
+++ b/scripts/repo-check.sh
@@ -35,6 +35,14 @@ run_step "CLI: build" "$REPO_ROOT/source/cli" "npm run build"
 # run would go green over zero E2E coverage. Fail loudly here instead.
 run_step "CLI: built binary present (E2E guard)" "$REPO_ROOT/source/cli" "test -f dist/bin.js || { echo 'dist/bin.js missing after build — E2E suites would silently skip'; exit 1; }"
 run_step "CLI: pack-smoke (A2)" "$REPO_ROOT/source/cli" "node scripts/pack-smoke.mjs"
+# Build the deterministic-verdict cache BEFORE the test run. The portal integration
+# tests assert count-parity against the real repo's filled lock (e.g. an advisory
+# deterministic refusal must tally as a warning). Those deterministic verdicts live in
+# the gitignored .yg-lock.deterministic.json, which is absent in a fresh checkout (CI or
+# a clean clone) — so without this the portal pairs read `unverified` and the parity
+# assertions fail. This is the free, keyless rebuild (no reviewer, writes only the
+# gitignored cache); the final "Graph: check" step below re-hashes it as the closing gate.
+run_step "Graph: deterministic cache (test prerequisite)" "$REPO_ROOT" "node source/cli/dist/bin.js check --approve --only-deterministic"
 run_step "CLI: test (with coverage)" "$REPO_ROOT/source/cli" "npm run test:coverage"
 run_step "CLI: coverage >= 90%" "$REPO_ROOT/source/cli" "node -e \"
 const j = require('./coverage/coverage-summary.json');

--- a/source/cli/tests/integration/portal-derive-catalogue.test.ts
+++ b/source/cli/tests/integration/portal-derive-catalogue.test.ts
@@ -113,6 +113,10 @@ describe('portal catalogue derivation (aspects / flows / types) — real repo', 
     });
   });
 
+  // Re-loads the whole real graph and re-hashes the lock (loadGraph + verifyLock over
+  // every node), the same heavy whole-repo work the beforeAll budgets 180s for. On a
+  // slow CI runner this exceeds vitest's 5s default, so it carries the same explicit
+  // budget — the work is bounded, the timeout only guards against a slow runner.
   it('flow count is derived and every real flow expands descendants', async () => {
     const graph = await loadGraph(REPO_ROOT);
     const lock = readLock(graph.rootPath);
@@ -132,7 +136,7 @@ describe('portal catalogue derivation (aspects / flows / types) — real repo', 
         expect(f.participants).toContain(declaredNode);
       }
     }
-  });
+  }, 180_000);
 });
 
 // ── Honest-rendering branch coverage over the builder functions directly ──────


### PR DESCRIPTION
## Why

`main`'s CI has been red since the 5.4.0 release. The portal work added a Playwright + Chromium e2e gate and deterministic-cache-backed portal integration tests to `repo-check.sh`, but the CI workflow was never taught to satisfy them in a fresh checkout. The failures are environment gaps, not product bugs — they reproduce only on a clean checkout (locally, Chromium and the cache are already present).

This was surfaced while triaging Dependabot PR #59 (a dev-dependency bump), whose red CI turned out to be inherited from this already-broken `main`, not caused by the bump.

## Root causes (all CI-environment, independent of any dependency)

1. **Chromium never installed.** `ci.yml` only ran `npm ci` + `repo-check.sh`. The portal e2e gate drives a real Chromium; its present-guard fails closed when the browser is missing, so every portal e2e spec errored.
2. **Deterministic cache rebuilt too late.** The portal integration tests assert count-parity against the real repo's filled lock. Deterministic verdicts live in the gitignored `.yg-lock.deterministic.json`, which is absent on a fresh checkout and was only rebuilt at the *end* of `repo-check.sh` — after the tests that read it. So the parity assertions saw `unverified` pairs and failed, cascading into the missing-coverage error.
3. **One heavy test had no explicit timeout.** The whole-repo "flow count" catalogue test re-loads the graph and re-hashes the lock; on a slow runner it tripped vitest's 5s default.

## Fix

- `ci.yml`: install Chromium (`npx playwright install --with-deps chromium`) before the gate — the exact command the guard already prints.
- `scripts/repo-check.sh`: rebuild the deterministic cache **before** the test step (free, keyless, writes only the gitignored cache), so a clean clone passes the same as a warm working tree. The final `Graph: check` step remains the closing gate.
- `portal-derive-catalogue.test.ts`: give the heavy whole-repo test the same 180s budget its sibling work already uses.
- Lock refreshed for the `test-deterministic` verdict on the edited test file (re-approved via the local `claude-code` reviewer). No source or graph behavior changed.

## Verification

Reproduced each failure locally by removing the gitignored cache (matching CI exactly), then ran the **full** `repo-check.sh` on a cold cache: with these fixes it goes green end-to-end — 5638 tests, coverage 97.7/96.0/97.6/90.2%, all portal e2e specs, docs, markdown lint, and `yg check` PASS (only the 3 pre-existing advisory warnings remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)